### PR TITLE
Created interface to make editing HTML structure easier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ For example:
 
 See the [examples](examples) directory for more sample templates.
 
+## Custom HTML and Strings
+
+The HTML can be completely altered from within the class without extending or manually iterating. By using strings we can edit the HTML on the fly.
+
+    $paginator = new \Helpers\Paginator($totalItems, $itemsPerPage, $currentPage, $urlPattern);
+
+    // each of the available strings are listed below
+    $this->strings['ulStart'] = '<ul class="pagination">'; // Start of the <ul>
+    $this->strings['ulEnd'] = '</ul>'; // end of the <ul>
+    $this->strings['pageLink'] = '<li (:active)><a href="(:url)">(:num)</a></li>'; // <li> object for each page of the pagination
+    $this->strings['disabledPageLink'] = '<li class="disabled"><span>(:num)</span></li>'; // disabled page
+    $this->strings['prev'] = '<li class="li-pagination-prev"><a class="pagination-prev icon" href="(:prev)">&laquo; Previous</a></li>'; // previous link
+    $this->strings['next'] = '<li class="li-pagination-next"><a class="pagination-next icon" href="(:next)">Next &raquo;</a></li>'; // next link
+
 ## Pages data structure
 
     $paginator->getPages();

--- a/src/JasonGrimes/Paginator.php
+++ b/src/JasonGrimes/Paginator.php
@@ -21,10 +21,12 @@ class Paginator
      */
     public function __construct($totalItems, $itemsPerPage, $currentPage, $urlPattern = '')
     {
-        $this->totalItems = $totalItems;
-        $this->itemsPerPage = $itemsPerPage;
-        $this->currentPage = $currentPage;
-        $this->urlPattern = $urlPattern;
+
+        // Improved validation
+        $this->totalItems     = $totalItems >= 0 ? $totalItems : 0;
+        $this->itemsPerPage   = $itemsPerPage >= 1 ? $itemsPerPage : 5;
+        $this->currentPage    = $currentPage != '' || $currentPage >= 1 ? $currentPage : 1;
+        $this->urlPattern     = $urlPattern != '' ? $urlPattern : '/page/(:num)';
 
         $this->updateNumPages();
     }
@@ -327,5 +329,16 @@ class Paginator
         }
 
         return $last;
+    }
+
+    /**
+     * Get the offset for database queries.
+     * 
+     * @return int returns the count # of the first element on the page
+     */
+    public function getOffset() {
+        
+        $offset = ($this->itemsPerPage * ($this->currentPage - 1)) ;
+        
     }
 }

--- a/src/JasonGrimes/Paginator.php
+++ b/src/JasonGrimes/Paginator.php
@@ -338,18 +338,18 @@ class Paginator
         $str = $this->strings[$strKey];
         
         if ($page != null) {
-            $vars = [
+            $vars = array(
                 'url' =>  $page['url'],
                 'active' => ($page['isCurrent'] ? ' class="location"' : ''),
                 'num' => $page['num']
-            ];
+            );
         }
         else {
         
-            $vars = [
+            $vars = array(
                 'next' => $this->getNextUrl(),
                 'prev' => $this->getPrevUrl()
-            ];  
+            );  
         }
         
         foreach ($vars as $key => $value) {

--- a/src/JasonGrimes/Paginator.php
+++ b/src/JasonGrimes/Paginator.php
@@ -12,6 +12,7 @@ class Paginator
     protected $currentPage;
     protected $urlPattern;
     protected $maxPagesToShow = 10;
+    protected $strings;
 
     /**
      * @param int $totalItems The total number of items.
@@ -27,6 +28,8 @@ class Paginator
         $this->itemsPerPage   = $itemsPerPage >= 1 ? $itemsPerPage : 5;
         $this->currentPage    = $currentPage != '' || $currentPage >= 1 ? $currentPage : 1;
         $this->urlPattern     = $urlPattern != '' ? $urlPattern : '/page/(:num)';
+
+        $this->setDefaultStrings();
 
         $this->updateNumPages();
     }
@@ -279,25 +282,80 @@ class Paginator
             return '';
         }
 
-        $html = '<ul class="pagination">';
+        $html = $this->strings['ulStart'];
         if ($this->getPrevUrl()) {
-            $html .= '<li><a href="' . $this->getPrevUrl() . '">&laquo; Previous</a></li>';
+            $prev = $this->parseString('prev');
+            $html .= $prev;
         }
 
         foreach ($this->getPages() as $page) {
+            
             if ($page['url']) {
-                $html .= '<li' . ($page['isCurrent'] ? ' class="active"' : '') . '><a href="' . $page['url'] . '">' . $page['num'] . '</a></li>';
+                $pageLink = $this->parseString('pageLink', $page);
+                $html .= $pageLink;
             } else {
-                $html .= '<li class="disabled"><span>' . $page['num'] . '</span></li>';
+                $pageLink = $this->parseString('disabledPageLink', $page);
+                $html .= $pageLink;
             }
         }
 
         if ($this->getNextUrl()) {
-            $html .= '<li><a href="' . $this->getNextUrl() . '">Next &raquo;</a></li>';
+            $next = $this->parseString('next');
+            $html .= $next;
         }
-        $html .= '</ul>';
+        $html .= $this->strings['ulEnd'];
 
         return $html;
+    }
+
+    /**
+     * Sets the default strings with the default HTML.
+     */
+    protected function setDefaultStrings() {
+        
+        $this->strings['ulStart'] = '<ul class="pagination">';
+        $this->strings['ulEnd'] = '</ul>';
+        
+        $this->strings['pageLink'] = '<li (:active)><a href="(:url)">(:num)</a></li>';
+        $this->strings['disabledPageLink'] = '<li class="disabled"><span>(:num)</span></li>';
+        
+        $this->strings['prev'] = '<li class="li-pagination-prev"><a class="pagination-prev icon" href="(:prev)">&laquo; Previous</a></li>';
+        $this->strings['next'] = '<li class="li-pagination-next"><a class="pagination-next icon" href="(:next)">Next &raquo;</a></li>';
+    }
+
+    /**
+     * Allows you to edit a string in the pagination layout
+     * 
+     * @param key of the string $$key
+     * @param type $html
+     */
+    public function setString($key, $html) {
+        $this->strings[$key] = $html;
+    }
+
+    protected function parseString($strKey, $page = null)
+    {
+        $str = $this->strings[$strKey];
+        
+        if ($page != null) {
+            $vars = [
+                'url' =>  $page['url'],
+                'active' => ($page['isCurrent'] ? ' class="location"' : ''),
+                'num' => $page['num']
+            ];
+        }
+        else {
+        
+            $vars = [
+                'next' => $this->getNextUrl(),
+                'prev' => $this->getPrevUrl()
+            ];  
+        }
+        
+        foreach ($vars as $key => $value) {
+            $str = str_replace('(:'.$key.')', $value, $str);
+        }
+        return $str;
     }
 
     public function __toString()
@@ -337,8 +395,6 @@ class Paginator
      * @return int returns the count # of the first element on the page
      */
     public function getOffset() {
-        
-        $offset = ($this->itemsPerPage * ($this->currentPage - 1)) ;
-        
+        return ($this->itemsPerPage * ($this->currentPage - 1)) ;
     }
 }


### PR DESCRIPTION
This update allows the developer to alter the sections of HTML on a per-pagination basis, or leave it as the default. Manually accessing the pagination system is okay, but things can be missed and cause discrepancies. 

You can edit the strings via the setString method and will automatically parse the strings for you. The README has been udpated to provide more info.