### PR TITLE
Add support for delegation of url generation

### DIFF
--- a/src/JasonGrimes/Paginator.php
+++ b/src/JasonGrimes/Paginator.php
@@ -14,6 +14,10 @@ class Paginator
     protected $maxPagesToShow = 10;
     protected $previousText = 'Previous';
     protected $nextText = 'Next';
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
 
     /**
      * @param int $totalItems The total number of items.
@@ -136,6 +140,9 @@ class Paginator
      */
     public function getPageUrl($pageNum)
     {
+        if($this->urlGenerator) {
+            return $this->urlGenerator->generatePageUrl($pageNum);
+        }
         return str_replace(self::NUM_PLACEHOLDER, $pageNum, $this->urlPattern);
     }
 
@@ -245,7 +252,7 @@ class Paginator
      *
      * @param int $pageNum
      * @param bool $isCurrent
-     * @return Array
+     * @return array
      */
     protected function createPage($pageNum, $isCurrent = false)
     {
@@ -340,6 +347,12 @@ class Paginator
     public function setNextText($text)
     {
         $this->nextText = $text;
+        return $this;
+    }
+
+    public function setUrlGenerator(UrlGeneratorInterface $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
         return $this;
     }
 }

--- a/src/JasonGrimes/UrlGeneratorInterface.php
+++ b/src/JasonGrimes/UrlGeneratorInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace JasonGrimes;
+
+
+interface UrlGeneratorInterface
+{
+    /**
+     * @param int $pageNumber
+     * @return string
+     */
+    public function generatePageUrl($pageNumber);
+}

--- a/tests/JasonGrimes/Tests/PaginatorTest.php
+++ b/tests/JasonGrimes/Tests/PaginatorTest.php
@@ -3,6 +3,7 @@
 namespace JasonGrimes\Tests;
 
 use JasonGrimes\Paginator;
+use JasonGrimes\UrlGeneratorInterface;
 
 class PaginatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -118,6 +119,31 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
             array(95, 10, 10, 91, 95),
             array(95, 10, 11, null, null), // If current page exceeds total items, first and last item are null.
         );
+    }
+
+    public function testUseUrlGenerator()
+    {
+        $paginator = new Paginator(10, 2, 1, 'index?page='.Paginator::NUM_PLACEHOLDER);
+        /**
+         * @var UrlGeneratorInterface $urlGenerator
+         */
+        $urlGenerator = $this->getMock('JasonGrimes\UrlGeneratorInterface');
+        $urlGenerator
+            ->expects($this->any())
+            ->method('generatePageUrl')
+            ->will($this->returnValueMap(array(
+                array(
+                    1,  'url-for-page-1'
+                ),
+                array(
+                    13,  'url-for-page-13'
+                )
+            )));
+        $paginator->setUrlGenerator($urlGenerator);
+        $this->assertEquals('url-for-page-1', $paginator->getPageUrl(1));
+        $this->assertEquals('url-for-page-13', $paginator->getPageUrl(13));
+        //Only url generator object is called when present
+        $this->assertEquals('', $paginator->getPageUrl(123));
     }
 
 }


### PR DESCRIPTION
This pull request will allow `Paginator` to delegate URL generation. This can be useful when integrating with frameworks that have have a routing service such as Symfony.
If a `UrlGeneratorInteface` object is not set `Paginator` defaults to using the url pattern