### PR TITLE
Add getOffset() method

### DIFF
--- a/src/JasonGrimes/Paginator.php
+++ b/src/JasonGrimes/Paginator.php
@@ -342,4 +342,9 @@ class Paginator
         $this->nextText = $text;
         return $this;
     }
+    
+    public function getOffset()
+    {
+        return ($this->currentPage - 1) * $this->itemsPerPage;
+    }
 }


### PR DESCRIPTION
Adding the `getOffset()` method so that it can be used in other contexts, for example, in an SQL query using `limit` and `offset` easily.